### PR TITLE
Python2 => Python3

### DIFF
--- a/mesh_tools/exfile.py
+++ b/mesh_tools/exfile.py
@@ -167,7 +167,7 @@ class Exregion(object):
                 expect_line(f, "Values:")
                 while len(values) < self.num_element_values:
                     line = f.readline()
-                    values.extend(map(float, line.split()))
+                    values.extend(list(map(float, line.split())))
     
 #Ignore faces, lines
             nodes = []   
@@ -180,7 +180,7 @@ class Exregion(object):
                 match = re.search(regex, element_line)
             while len(nodes) < self.num_nodes:
                 line = f.readline()
-                nodes.extend(map(int, line.split()))
+                nodes.extend(list(map(int, line.split())))
     
             scale_factors = []
             element_line = f.readline()
@@ -188,7 +188,7 @@ class Exregion(object):
             if re.search(regex, element_line) is not None: 
                 while len(scale_factors) < self.num_scale_factors:
                     line = f.readline()
-                    scale_factors.extend(map(float, line.split()))
+                    scale_factors.extend(list(map(float, line.split())))
             else:
                 f.rollback()
             
@@ -338,7 +338,7 @@ class ExnodeSection(object):
         while read < self.num_node_values:
             line = f.readline()
             try:
-                new_values = map(float, line.split())
+                new_values = list(map(float, line.split()))
             except ValueError:
                 raise ExfileError(f, "Expecting node values, got: %s" % line.strip())
 
@@ -636,15 +636,15 @@ class ExelemComponent(object):
                     r'[0-9]+\.\s*#Values\s*=\s*([0-9]+)')
             value_indices_line = f.readline().strip()
             scale_factor_indices_line = f.readline().strip()
-            self.value_indices[node] = map(int,
-                    value_indices_line.split(':')[1].strip().split())
-            self.scale_factor_indices[node] = map(int,
-                    scale_factor_indices_line.split(':')[1].strip().split())
+            self.value_indices[node] = list(map(int,
+                    value_indices_line.split(':')[1].strip().split()))
+            self.scale_factor_indices[node] = list(map(int,
+                    scale_factor_indices_line.split(':')[1].strip().split()))
 
     def _read_grid_component(self, f):
         grids = f.readline()
         divisions = [d.strip().split('=')[1] for d in grids.split(',')]
-        self.divisions = map(int, divisions)
+        self.divisions = list(map(int, divisions))
 
     def __repr__(self):
         return '<ExnodeComponent, "%s": "%s">' % (

--- a/mesh_tools/exfile.py
+++ b/mesh_tools/exfile.py
@@ -156,7 +156,7 @@ class Exregion(object):
         if element_line == "":
             raise EOFError
         try:
-            indices = map(int, element_line.split(':')[1].split())
+            indices = list(map(int, element_line.split(':')[1].split()))
         except:
             print(element_line)
             raise
@@ -528,36 +528,36 @@ class Exelem(object):
                 element_line = f.readline()
         if element_line == "":
             raise EOFError
-        indices = map(int, element_line.split(':')[1].split())
+        indices = list(map(int, element_line.split(':')[1].split()))
         values = []
         if self.num_element_values > 0:
             expect_line(f, "Values:")
             while len(values) < self.num_element_values:
                 line = f.readline()
-                values.extend(map(float, line.split()))
+                values.extend(list(map(float, line.split())))
         line = f.readline().strip()
         nodes = []
         if line == "Faces:":
             faces = []
             while len(faces) <= 15:
                 line = f.readline()
-                faces.extend(map(int, line.split()))
+                faces.extend(list(map(int, line.split())))
             temp = f.readline().strip()
             nodes = []
             while len(nodes) < self.num_nodes:
                 line = f.readline()
-                nodes.extend(map(int, line.split()))
+                nodes.extend(list(map(int, line.split())))
         elif line == "Nodes:":
             nodes = []
             while len(nodes) < self.num_nodes:
                 line = f.readline()
-                nodes.extend(map(int, line.split()))
+                nodes.extend(list(map(int, line.split())))
     
         expect_line(f, "Scale factors:")
         scale_factors = []
         while len(scale_factors) < self.num_scale_factors:
             line = f.readline()
-            scale_factors.extend(map(float, line.split()))
+            scale_factors.extend(list(map(float, line.split())))
             #for i in range(0, 8):
             #    n = nodes[i]
             #    self.scale_factors[n-1, :] = scale_factors[i*8:(i+1)*8]

--- a/mesh_tools/mesh_conversions.py
+++ b/mesh_tools/mesh_conversions.py
@@ -1,5 +1,5 @@
 import numpy as np
-import exfile
+from mesh_tools import exfile
 from opencmiss.iron import iron
 import morphic
 
@@ -40,7 +40,7 @@ def exfile_to_morphic(nodeFilename, elementFilename, coordinateField,
             coordinates.append(componentValues)
 
         mesh.add_stdnode(node_num, coordinates, group='_default')
-        print('Morhpic node added', node_num, coordinates)
+        print('Morphic node added', node_num, coordinates)
 
     if dimension == 2:
         if interpolation == 'linear':
@@ -136,7 +136,7 @@ def morphic_to_OpenCMISS(morphicMesh, region, basis, meshUserNumber,
         mesh.NumberOfComponentsSet(1)
 
     node_list = morphicMesh.get_node_ids()[1]
-    element_list = morphicMesh.get_element_ids()
+    element_list = morphicMesh.get_element_cids()
 
     mesh.NumberOfElementsSet(len(element_list))
     nodes = iron.Nodes()
@@ -172,9 +172,7 @@ def morphic_to_OpenCMISS(morphicMesh, region, basis, meshUserNumber,
         derivatives = range(1,9)
     coordinates = np.zeros((len(node_list), 3,len(derivatives)))
     for node_idx,morphic_node in enumerate(morphicMesh.nodes):
-        print("node: ", morphic_node.id)
         for comp_idx in range(3):
-            print("component: ", comp_idx + 1)
             for derivative_idx, derivative in enumerate(derivatives):
                 coordinates[node_idx, comp_idx, derivative_idx] = morphic_node.values[comp_idx]
 

--- a/mesh_tools/opencmiss_fields.py
+++ b/mesh_tools/opencmiss_fields.py
@@ -1,6 +1,6 @@
 import numpy as np
 from opencmiss.iron import iron
-import fields
+import mesh_tools.fields
 
 def interpolate_field(field, element_ids=[], num_values=4,dimension=3, derivative_number=1, xi=None, elems=None):
 


### PR DESCRIPTION
Fixed imports
Fixed print statements now requiring parentheses
Fixed `map()` used as a list
Fixed `morphicMesh.get_element_ids()` which is now called `morphicMesh.get_element_cids()`